### PR TITLE
Fix ReflectionBasics for actually transparent `createTuple`

### DIFF
--- a/src/main/scala/com/rockthejvm/macros/ReflectionBasics.scala
+++ b/src/main/scala/com/rockthejvm/macros/ReflectionBasics.scala
@@ -37,13 +37,14 @@ object ReflectionBasics {
       if (n == 0) '{ EmptyTuple } 
       else '{ $value *: ${ buildTupleSimple(n - 1) } }
 
-    def buildTupleExpr(tpe: Type[? <: AnyKind]): Expr[Tuple] = 
+    def buildTupleExpr(tpe: Type[? <: AnyKind]): Expr[Tuple] =
       tpe match {
-        case '[A *: rt] => 
-          '{ $value *: ${ buildTupleExpr(TypeRepr.of[rt].asType) } }
-        case _ => '{ EmptyTuple }
+        case '[A *: rt] =>
+          '{ $value *: ${ buildTupleExpr(TypeRepr.of[rt].asType).asExprOf[rt] } }
+        case _ =>
+          '{ EmptyTuple }
       }
-
+    
     inline def buildTupleComplicated(n: Int): Expr[Tuple] = {
       // defn = package for meta-definitions in Scala
       // 1 - build the type constructor => TupleN


### PR DESCRIPTION
At least in Scala 3.7.3, without that `asExprOf` down-casting, the macro isn't actually transparent, so the following fails, the return type being `String *: Tuple` instead of `(String, String, String)` as one would expect:

```
[error] 26 |  val n: (String, String, String) = createTuple[3, String]("Scala")
[error]    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]    |                                    Found:    String *: Tuple
[error]    |                                    Required: (String, String, String)
```